### PR TITLE
Feature(PR-151): REST and Emulator Support

### DIFF
--- a/src/DatastoreConnection.php
+++ b/src/DatastoreConnection.php
@@ -63,7 +63,7 @@ class DatastoreConnection extends Connection
     public function makeClient($config): DatastoreConnection
     {
         $client = new DatastoreClient([
-            'keyFilePath' => $config['key_file_path'] ?? base_path('gcloud-credentials.json'),
+            'keyFilePath' => $config['key_file_path'] ?? null,
             'transport' => $config['transport'] ?? 'grpc',
         ]);
 

--- a/src/DatastoreConnection.php
+++ b/src/DatastoreConnection.php
@@ -64,6 +64,7 @@ class DatastoreConnection extends Connection
     {
         $client = new DatastoreClient([
             'keyFilePath' => $config['key_file_path'] ?? base_path('gcloud-credentials.json'),
+            'transport' => $config['transport'] ?? 'grpc',
         ]);
 
         return $this->setClient($client);


### PR DESCRIPTION
- Use `transport` if it's passed in so `rest` can be selected.
- Make `key_file_path` optional. This way the local emulator can be used without having a valid credentials json file.